### PR TITLE
Change csound compile behavior to include reset on failure and avoid error

### DIFF
--- a/lib/ide-csound.coffee
+++ b/lib/ide-csound.coffee
@@ -69,7 +69,10 @@ Csound =
         result = csound.CompileArgs @Csound, ['csound', editor.getPath()]
       else
         result = csound.CompileOrc @Csound, editor.getText()
-    return if result isnt csound.CSOUND_SUCCESS
+    if result isnt csound.CSOUND_SUCCESS
+      csound.Reset @Csound
+      return
+
 
     result = csound.Start @Csound
     if result is csound.CSOUND_SUCCESS


### PR DESCRIPTION
To correct an error that may be reproduced on OSX 10.10.5 by attempting to compile any .csd file that contains syntactical errors. When attempting to compile the error-bearing file, the plugin throws parser errors as expected. However, upon correcting the errors and attempting to recompile the plugin throws a new funky and mysterious error:

```Csound Command ERROR:    too many arguments```

The `Csound Command ERROR` was not limited to the original file, being also reproducible by attempting to compile a second error-free file after trying to compile the first error-bearing file. Tthis problem seems analogous to Csound requiring reinstantiation parser error, as seen here [https://github.com/csound/csound/issues/305](https://github.com/csound/csound/issues/305)

To correct it, I just tweaked your `if/return` block following the `csound.Compile` calls to also include `csound.Reset @Csound` call.

This (and your npm csound-api) are awesome, thanks for your work!  :+1: 